### PR TITLE
chore: consistency overhaul

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,6 @@ name: Publish
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Release tag to publish (e.g. v1.0.2)"
-        required: true
 
 jobs:
   publish-npm:
@@ -15,30 +10,25 @@ jobs:
     permissions:
       contents: read
       id-token: write
-
     steps:
       - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           registry-url: https://registry.npmjs.org
 
-      - name: Resolve tag
-        id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
-          fi
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
-      - name: Download release tarball
-        run: gh release download ${{ steps.tag.outputs.tag }} --pattern "*.tgz"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: bun run build
 
       - name: Publish to npm
-        run: npm publish *.tgz --access public --provenance
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,28 +5,28 @@ MCP server for [Grafana](https://grafana.com/) — manage dashboards, datasource
 ## Installation
 
 ```bash
-npx -y @daanrongen/grafana-mcp
+bunx @daanrongen/grafana-mcp
 ```
 
 ## Tools (17 total)
 
-| Domain          | Tools                                                                                   | Coverage                                             |
-| --------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| **Dashboards**  | `list_dashboards`, `get_dashboard`, `create_dashboard`, `update_dashboard`, `delete_dashboard` | Full dashboard lifecycle                      |
-| **Datasources** | `list_datasources`, `get_datasource`, `create_datasource`, `delete_datasource`          | Datasource management                                |
-| **Alerts**      | `list_alert_rules`, `get_alert_rule`, `list_alert_instances`                            | Alert rules and firing Alertmanager instances        |
-| **Folders**     | `list_folders`, `create_folder`, `delete_folder`                                        | Folder organisation                                  |
-| **Annotations** | `list_annotations`, `create_annotation`                                                 | Dashboard and global annotations                     |
-| **Health**      | `health_check`                                                                          | Grafana instance status                              |
+| Domain          | Tools                                                                                        | Coverage                                       |
+| --------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **Dashboards**  | `list_dashboards`, `get_dashboard`, `create_dashboard`, `update_dashboard`, `delete_dashboard` | Full dashboard lifecycle                     |
+| **Datasources** | `list_datasources`, `get_datasource`, `create_datasource`, `delete_datasource`               | Datasource management                          |
+| **Alerts**      | `list_alert_rules`, `get_alert_rule`, `list_alert_instances`                                 | Alert rules and firing Alertmanager instances  |
+| **Folders**     | `list_folders`, `create_folder`, `delete_folder`                                             | Folder organisation                            |
+| **Annotations** | `list_annotations`, `create_annotation`                                                      | Dashboard and global annotations               |
+| **Health**      | `health_check`                                                                               | Grafana instance status                        |
+
+## Configuration
+
+| Variable          | Required | Description                                     |
+| ----------------- | -------- | ----------------------------------------------- |
+| `GRAFANA_URL`     | Yes      | Grafana base URL (e.g. `http://localhost:3000`) |
+| `GRAFANA_API_KEY` | Yes      | Grafana service account token or API key        |
 
 ## Setup
-
-### Environment variables
-
-| Variable          | Required | Description                                         |
-| ----------------- | -------- | --------------------------------------------------- |
-| `GRAFANA_URL`     | Yes      | Grafana base URL (e.g. `http://localhost:3000`)     |
-| `GRAFANA_API_KEY` | Yes      | Grafana service account token or API key            |
 
 ### Claude Desktop
 
@@ -37,8 +37,8 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "grafana": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@daanrongen/grafana-mcp"],
+      "command": "bunx",
+      "args": ["@daanrongen/grafana-mcp"],
       "env": {
         "GRAFANA_URL": "http://localhost:3000",
         "GRAFANA_API_KEY": "your-service-account-token"
@@ -48,13 +48,13 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
-Or via the CLI:
+### Claude Code CLI
 
 ```bash
 claude mcp add grafana \
   -e GRAFANA_URL=http://localhost:3000 \
   -e GRAFANA_API_KEY=your-service-account-token \
-  -- npx -y @daanrongen/grafana-mcp
+  -- bunx @daanrongen/grafana-mcp
 ```
 
 ## Development
@@ -63,25 +63,46 @@ claude mcp add grafana \
 bun install
 bun run dev        # run with --watch
 bun test           # run test suite
+bun run typecheck  # type-check with tsc
+bun run lint       # biome lint
+bun run format     # biome format
 bun run build      # bundle to dist/main.js
-bun run inspect    # open MCP Inspector in browser
 ```
+
+## Inspecting locally
+
+Use the MCP Inspector to browse and call tools interactively against a real Grafana instance:
+
+```bash
+GRAFANA_URL=http://localhost:3000 \
+GRAFANA_API_KEY=your-service-account-token \
+bun run inspect
+```
+
+This opens the MCP Inspector UI in the browser, pointed at the locally built server.
 
 ## Architecture
 
 ```
 src/
-├── config.ts                  # Effect Config — GRAFANA_URL, GRAFANA_API_KEY
-├── main.ts                    # Entry point — ManagedRuntime + StdioServerTransport
+├── config.ts                   # Effect Config — GRAFANA_URL, GRAFANA_API_KEY
+├── main.ts                     # Entry point — ManagedRuntime + StdioServerTransport
 ├── domain/
-│   ├── GrafanaClient.ts       # Context.Tag service interface
-│   ├── errors.ts              # GrafanaError, NotFoundError
-│   └── models.ts              # Schema.Class models (Dashboard, Datasource, AlertRule, …)
+│   ├── GrafanaClient.ts        # Context.Tag service interface (port)
+│   ├── errors.ts               # GrafanaError, NotFoundError
+│   ├── models.ts               # Schema.Class models (Dashboard, Datasource, AlertRule, …)
+│   ├── dashboards.test.ts      # Domain tests using GrafanaClientTest
+│   ├── datasources.test.ts     # Domain tests using GrafanaClientTest
+│   └── health.test.ts          # Domain tests using GrafanaClientTest
 ├── infra/
-│   ├── GrafanaClientLive.ts   # Layer using fetch against the Grafana HTTP API
-│   └── GrafanaClientTest.ts   # In-memory Ref-based test adapter
+│   ├── GrafanaClientLive.ts    # Layer using fetch against the Grafana HTTP API
+│   └── GrafanaClientTest.ts    # In-memory Ref-based test adapter
 └── mcp/
-    ├── server.ts              # McpServer wired to ManagedRuntime
-    ├── utils.ts               # formatSuccess, formatError
-    └── tools/                 # dashboards.ts, datasources.ts, alerts.ts, folders.ts, annotations.ts, health.ts
+    ├── server.ts               # McpServer wired to ManagedRuntime
+    ├── utils.ts                # formatSuccess, formatError
+    └── tools/                  # dashboards.ts, datasources.ts, alerts.ts, folders.ts, annotations.ts, health.ts
 ```
+
+## License
+
+MIT

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "files": {
     "includes": ["**", "!dist", "!node_modules"]
   },

--- a/bun.lock
+++ b/bun.lock
@@ -5,40 +5,40 @@
     "": {
       "name": "@daanrongen/grafana-mcp",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.2",
-        "effect": "^3.13.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "effect": "^3.21.0",
         "zod": "^3.24.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.8",
+        "@biomejs/biome": "^2.4.12",
         "bun-types": "latest",
-        "lefthook": "^2.1.4",
+        "lefthook": "^2.1.5",
         "typescript": "^5.8.3",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.28.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -148,27 +148,27 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
-    "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
+    "lefthook": ["lefthook@2.1.5", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.5", "lefthook-darwin-x64": "2.1.5", "lefthook-freebsd-arm64": "2.1.5", "lefthook-freebsd-x64": "2.1.5", "lefthook-linux-arm64": "2.1.5", "lefthook-linux-x64": "2.1.5", "lefthook-openbsd-arm64": "2.1.5", "lefthook-openbsd-x64": "2.1.5", "lefthook-windows-arm64": "2.1.5", "lefthook-windows-x64": "2.1.5" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-yB9IFWurFllusbPZqvG0EavTmpNXPya2MuO7Li7YT78xAj3uCQ3AgmW9TVUbTTsSMhsegbiAMRpwfEk2TP1P0A=="],
 
-    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BUAAE9+rUrjr39a+wH/1zHmGrDdwUQ2Yq/z6BQbM/yUb9qtXBRcQ5eOXxApqWW177VhGBpX31aqIlfAZ5Q7wzw=="],
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VITTaw8PxxyE26gkZ8UcwIa5ZrWnKNRGLeeSrqri40cQdXvLTEoMq2tjjw7eiL9UcB0waRReDdzydevy9GOPUQ=="],
 
-    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-K1ncIMEe84fe+ss1hQNO7rIvqiKy2TJvTFpkypvqFodT7mJXZn7GLKYTIXdIuyPAYthRa9DwFnx5uMoHwD2F1Q=="],
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-AvtjYiW0BSGHBGrdvL313seUymrW9FxI+6JJwJ+ZSaa2sH81etrTB0wAwlH1L9VfFwK9+gWvatZBvLfF3L4fPw=="],
 
-    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-PVUhjOhVN71YaYsVdQyNbFZ4a2jFB2Tg5hKrrn9kaWpx64aLz/XivLjwr8sEuTaP1GRlEWBpW6Bhrcsyo39qFw=="],
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-mXjJwe8jKGWGiBYUxfQY1ab3Nn5NhafqT9q3KJz8m5joGGQj4JD0cbWxF1nVBLBWsDGbWZRZunTCMGcIScT2bQ=="],
 
-    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ZWV9o/LeyWNEBoVO+BhLqxH3rGTba05nkm5NvMjEFSj7LbUNUDbQmupZwtHl1OMGJO66eZP0CalzRfUH6GhBxQ=="],
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-exD69dCjc1K45BxatDPGoH4NmEvgLKPm4kJLOWn1fTeHRKZwWiFPwnjknEoG2OemlCDHmCU++5X40kMEG0WBlA=="],
 
-    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iWN0pGnTjrIvNIcSI1vQBJXUbybTqJ5CLMniPA0olabMXQfPDrdMKVQe+mgdwHK+E3/Y0H0ZNL3lnOj6Sk6szA=="],
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-57TDKC5ewWpsCLZQKIJMHumFEObYKVundmPpiWhX491hINRZYYOL/26yrnVnNcidThRzTiTC+HLcuplLcaXtbA=="],
 
-    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-96bTBE/JdYgqWYAJDh+/e/0MaxJ25XTOAk7iy/fKoZ1ugf6S0W9bEFbnCFNooXOcxNVTan5xWKfcjJmPIKtsJA=="],
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-bqK3LrAB5l5YaCaoHk6qRWlITrGWzP4FbwRxA31elbxjd0wgNWZ2Sn3zEfSEcxz442g7/PPkEwqqsTx0kSFzpg=="],
 
-    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-oYUoK6AIJNEr9lUSpIMj6g7sWzotvtc3ryw7yoOyQM6uqmEduw73URV/qGoUcm4nqqmR93ZalZwR2r3Gd61zvw=="],
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.5", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-5aSwK7vV3A6t0w9PnxCMiVjQlcvopBP50BtmnnLnNJyAYHnFbZ0Baq5M0WkE9IsUkWSux0fe6fd0jDkuG711MA=="],
 
-    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/Dv9Jcm68y9cggr1PhyUhOabBGP9+hzQPoiyOhKks7y9qrJl79A8XfG6LHekSuYc2VpiSu5wdnnrE1cj2nfTg=="],
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Y+pPdDuENJ8qWnUgL02xxhpjblc0WnwXvWGfqnl3WZrAgHzQpwx3G6469RID/wlNVdHYAlw3a8UkFSMYsTzXvA=="],
 
-    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-hSww7z+QX4YMnw2lK7DMrs3+w7NtxksuMKOkCKGyxUAC/0m1LAICo0ZbtdDtZ7agxRQQQ/SEbzFRhU5ysNcbjA=="],
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-2PlcFBjTzJaMufw0c28kfhB/0zmaRCU0TRPPsil/HU2YNOExod4upPGLk9qjgsOmb2YVWFz6zq6u7+D1yqmzTQ=="],
 
-    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-eE68LwnogxwcPgGsbVGPGxmghyMGmU9SdGwcc+uhGnUxPz1jL89oECMWJNc36zjVK24umNeDAzB5KA3lw1MuWw=="],
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-yiAh8qxml6uqy10jDxOdN9fOQpyLxBFY1fgCEAhn7sVJYmJKRhjqSBwZX6LG5MQjzr29KStrIdw7TR3lf3rT7Q=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,11 +1,11 @@
 pre-commit:
-  parallel: true
   commands:
     format:
       run: bun run format
       stage_fixed: true
     lint:
       run: bun run lint
+      depends_on: ["format"]
 
 pre-push:
   commands:

--- a/package.json
+++ b/package.json
@@ -3,15 +3,12 @@
   "version": "1.0.2",
   "description": "MCP server for Grafana — manage dashboards, datasources, alerts, folders, and annotations over stdio",
   "type": "module",
-  "bin": {
-    "grafana-mcp": "dist/main.js"
-  },
+  "bin": "./dist/main.js",
   "main": "./dist/main.js",
   "files": [
     "dist"
   ],
   "scripts": {
-    "start": "bun run src/main.ts",
     "dev": "bun --watch src/main.ts",
     "inspect": "DANGEROUSLY_OMIT_AUTH=true mcp-inspector bun dist/main.js",
     "build": "bun build src/main.ts --outfile dist/main.js --target bun",
@@ -25,6 +22,9 @@
     "postversion": "git push --follow-tags"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/daanrongen/grafana-mcp.git"
@@ -40,14 +40,14 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2",
-    "effect": "^3.13.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "effect": "^3.21.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.8",
+    "@biomejs/biome": "^2.4.12",
     "bun-types": "latest",
-    "lefthook": "^2.1.4",
+    "lefthook": "^2.1.5",
     "typescript": "^5.8.3"
   }
 }

--- a/src/domain/dashboards.test.ts
+++ b/src/domain/dashboards.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
-import { GrafanaClient } from "../../src/domain/GrafanaClient.ts";
-import { GrafanaClientTest } from "../../src/infra/GrafanaClientTest.ts";
+import { GrafanaClientTest } from "../infra/GrafanaClientTest.ts";
+import { GrafanaClient } from "./GrafanaClient.ts";
 
 describe("dashboards", () => {
   it("listDashboards returns empty list initially", async () => {

--- a/src/domain/datasources.test.ts
+++ b/src/domain/datasources.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
-import { GrafanaClient } from "../../src/domain/GrafanaClient.ts";
-import { GrafanaClientTest } from "../../src/infra/GrafanaClientTest.ts";
+import { GrafanaClientTest } from "../infra/GrafanaClientTest.ts";
+import { GrafanaClient } from "./GrafanaClient.ts";
 
 describe("datasources", () => {
   it("listDatasources returns empty list initially", async () => {

--- a/src/domain/health.test.ts
+++ b/src/domain/health.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
-import { GrafanaClient } from "../../src/domain/GrafanaClient.ts";
-import { GrafanaClientTest } from "../../src/infra/GrafanaClientTest.ts";
+import { GrafanaClientTest } from "../infra/GrafanaClientTest.ts";
+import { GrafanaClient } from "./GrafanaClient.ts";
 
 describe("health", () => {
   it("healthCheck returns ok status", async () => {


### PR DESCRIPTION
## Summary
- Bump deps: MCP SDK ^1.29.0, effect ^3.21.0, zod ^3.24.1, TS ^5.8.3, biome ^2.4.12
- Colocate tests in src/domain/ (from tests/domain/)
- Standardise lefthook.yml, biome.json, CI workflows
- Replace unique publish.yml with canonical rebuild pattern
- Add publishConfig, fix bin path, remove redundant start script
- Update README: bunx, canonical structure, add Inspecting locally, License section

Closes #1