### PR TITLE
fix: use object format for bin field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.4",
   "description": "MCP server for Grafana — manage dashboards, datasources, alerts, folders, and annotations over stdio",
   "type": "module",
-  "bin": "./dist/main.js",
+  "bin": {
+    "grafana-mcp": "./dist/main.js"
+  },
   "main": "./dist/main.js",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- Changes `bin` from a string (`"./dist/main.js"`) to an object (`{"grafana-mcp": "./dist/main.js"}`) in `package.json`
- The string form causes npm to auto-correct during publish and emit a warning; the object form is the canonical spec

## Test plan

- [x] Linter passes (`bun run lint`)
- [x] Build succeeds (`bun run build`)
- [x] All 13 tests pass (`bun test`)
- [x] Type check passes (`bun run typecheck`)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)