### PR TITLE
refactor: extract runTool helper, remove redundant Layer.mergeAll

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,10 @@
 #!/usr/bin/env bun
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { Layer, ManagedRuntime } from "effect";
+import { ManagedRuntime } from "effect";
 import { GrafanaClientLive } from "./infra/GrafanaClientLive.ts";
 import { createMcpServer } from "./mcp/server.ts";
 
-const layer = Layer.mergeAll(GrafanaClientLive);
-
-const runtime = ManagedRuntime.make(layer);
+const runtime = ManagedRuntime.make(GrafanaClientLive);
 
 const server = createMcpServer(runtime);
 

--- a/src/mcp/tools/alerts.ts
+++ b/src/mcp/tools/alerts.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { z } from "zod";
 import type { GrafanaError, NotFoundError } from "../../domain/errors.ts";
 import { GrafanaClient } from "../../domain/GrafanaClient.ts";
-import { formatError, formatSuccess } from "../utils.ts";
+import { runTool } from "../utils.ts";
 
 export const registerAlertTools = (
   server: McpServer,
@@ -15,16 +15,14 @@ export const registerAlertTools = (
     "List all Grafana alert rules. Returns uid, title, condition, folder, rule group, and state settings.",
     {},
     { title: "List Alert Rules", readOnlyHint: true, openWorldHint: true },
-    async () => {
-      const result = await runtime.runPromiseExit(
+    () =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.listAlertRules();
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -34,16 +32,14 @@ export const registerAlertTools = (
       uid: z.string().describe("Alert rule UID"),
     },
     { title: "Get Alert Rule", readOnlyHint: true, openWorldHint: true },
-    async ({ uid }) => {
-      const result = await runtime.runPromiseExit(
+    ({ uid }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.getAlertRule(uid);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -51,15 +47,13 @@ export const registerAlertTools = (
     "List currently firing Grafana alert instances from Alertmanager. Returns labels, state, and activeAt.",
     {},
     { title: "List Alert Instances", readOnlyHint: true, openWorldHint: true },
-    async () => {
-      const result = await runtime.runPromiseExit(
+    () =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.listAlertInstances();
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 };

--- a/src/mcp/tools/annotations.ts
+++ b/src/mcp/tools/annotations.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { z } from "zod";
 import type { GrafanaError, NotFoundError } from "../../domain/errors.ts";
 import { GrafanaClient } from "../../domain/GrafanaClient.ts";
-import { formatError, formatSuccess } from "../utils.ts";
+import { runTool } from "../utils.ts";
 
 export const registerAnnotationTools = (
   server: McpServer,
@@ -18,16 +18,14 @@ export const registerAnnotationTools = (
       limit: z.number().optional().describe("Maximum number of results (default: 100)"),
     },
     { title: "List Annotations", readOnlyHint: true, openWorldHint: true },
-    async ({ dashboardUid, limit }) => {
-      const result = await runtime.runPromiseExit(
+    ({ dashboardUid, limit }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.listAnnotations(dashboardUid, limit);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -49,15 +47,13 @@ export const registerAnnotationTools = (
       destructiveHint: false,
       openWorldHint: true,
     },
-    async ({ text, tags, dashboardUid, time, timeEnd }) => {
-      const result = await runtime.runPromiseExit(
+    ({ text, tags, dashboardUid, time, timeEnd }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.createAnnotation(text, tags, dashboardUid, time, timeEnd);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 };

--- a/src/mcp/tools/dashboards.ts
+++ b/src/mcp/tools/dashboards.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { z } from "zod";
 import type { GrafanaError, NotFoundError } from "../../domain/errors.ts";
 import { GrafanaClient } from "../../domain/GrafanaClient.ts";
-import { formatError, formatSuccess } from "../utils.ts";
+import { runTool } from "../utils.ts";
 
 export const registerDashboardTools = (
   server: McpServer,
@@ -18,16 +18,14 @@ export const registerDashboardTools = (
       limit: z.number().optional().describe("Maximum number of results (default: 100)"),
     },
     { title: "List Dashboards", readOnlyHint: true, openWorldHint: true },
-    async ({ query, limit }) => {
-      const result = await runtime.runPromiseExit(
+    ({ query, limit }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.listDashboards(query, limit);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -37,16 +35,14 @@ export const registerDashboardTools = (
       uid: z.string().describe("Dashboard UID"),
     },
     { title: "Get Dashboard", readOnlyHint: true, openWorldHint: true },
-    async ({ uid }) => {
-      const result = await runtime.runPromiseExit(
+    ({ uid }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.getDashboard(uid);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -60,16 +56,14 @@ export const registerDashboardTools = (
       message: z.string().optional().describe("Commit message for the dashboard version"),
     },
     { title: "Create Dashboard", readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-    async ({ dashboardJson, folderUid, message }) => {
-      const result = await runtime.runPromiseExit(
+    ({ dashboardJson, folderUid, message }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.createDashboard(dashboardJson, folderUid, message);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -81,16 +75,14 @@ export const registerDashboardTools = (
       message: z.string().optional().describe("Commit message for the new version"),
     },
     { title: "Update Dashboard", readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-    async ({ uid, dashboardJson, message }) => {
-      const result = await runtime.runPromiseExit(
+    ({ uid, dashboardJson, message }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.updateDashboard(uid, dashboardJson, message);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -100,15 +92,14 @@ export const registerDashboardTools = (
       uid: z.string().describe("Dashboard UID"),
     },
     { title: "Delete Dashboard", readOnlyHint: false, destructiveHint: true, openWorldHint: true },
-    async ({ uid }) => {
-      const result = await runtime.runPromiseExit(
+    ({ uid }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           yield* client.deleteDashboard(uid);
+          return { ok: true };
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess({ ok: true });
-    },
+      ),
   );
 };

--- a/src/mcp/tools/datasources.ts
+++ b/src/mcp/tools/datasources.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { z } from "zod";
 import type { GrafanaError, NotFoundError } from "../../domain/errors.ts";
 import { GrafanaClient } from "../../domain/GrafanaClient.ts";
-import { formatError, formatSuccess } from "../utils.ts";
+import { runTool } from "../utils.ts";
 
 export const registerDatasourceTools = (
   server: McpServer,
@@ -15,16 +15,14 @@ export const registerDatasourceTools = (
     "List all configured Grafana datasources. Returns id, uid, name, type, url, and isDefault.",
     {},
     { title: "List Datasources", readOnlyHint: true, openWorldHint: true },
-    async () => {
-      const result = await runtime.runPromiseExit(
+    () =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.listDatasources();
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -34,16 +32,14 @@ export const registerDatasourceTools = (
       uid: z.string().describe("Datasource UID"),
     },
     { title: "Get Datasource", readOnlyHint: true, openWorldHint: true },
-    async ({ uid }) => {
-      const result = await runtime.runPromiseExit(
+    ({ uid }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.getDatasource(uid);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -61,16 +57,14 @@ export const registerDatasourceTools = (
       destructiveHint: false,
       openWorldHint: true,
     },
-    async ({ name, type, url, isDefault }) => {
-      const result = await runtime.runPromiseExit(
+    ({ name, type, url, isDefault }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.createDatasource(name, type, url, isDefault);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -80,15 +74,14 @@ export const registerDatasourceTools = (
       uid: z.string().describe("Datasource UID"),
     },
     { title: "Delete Datasource", readOnlyHint: false, destructiveHint: true, openWorldHint: true },
-    async ({ uid }) => {
-      const result = await runtime.runPromiseExit(
+    ({ uid }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           yield* client.deleteDatasource(uid);
+          return { ok: true };
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess({ ok: true });
-    },
+      ),
   );
 };

--- a/src/mcp/tools/folders.ts
+++ b/src/mcp/tools/folders.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { z } from "zod";
 import type { GrafanaError, NotFoundError } from "../../domain/errors.ts";
 import { GrafanaClient } from "../../domain/GrafanaClient.ts";
-import { formatError, formatSuccess } from "../utils.ts";
+import { runTool } from "../utils.ts";
 
 export const registerFolderTools = (
   server: McpServer,
@@ -15,16 +15,14 @@ export const registerFolderTools = (
     "List all Grafana folders. Returns uid, title, and url.",
     {},
     { title: "List Folders", readOnlyHint: true, openWorldHint: true },
-    async () => {
-      const result = await runtime.runPromiseExit(
+    () =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.listFolders();
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -35,16 +33,14 @@ export const registerFolderTools = (
       uid: z.string().optional().describe("Optional custom UID for the folder"),
     },
     { title: "Create Folder", readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-    async ({ title, uid }) => {
-      const result = await runtime.runPromiseExit(
+    ({ title, uid }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.createFolder(title, uid);
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 
   server.tool(
@@ -54,15 +50,14 @@ export const registerFolderTools = (
       uid: z.string().describe("Folder UID"),
     },
     { title: "Delete Folder", readOnlyHint: false, destructiveHint: true, openWorldHint: true },
-    async ({ uid }) => {
-      const result = await runtime.runPromiseExit(
+    ({ uid }) =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           yield* client.deleteFolder(uid);
+          return { ok: true };
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess({ ok: true });
-    },
+      ),
   );
 };

--- a/src/mcp/tools/health.ts
+++ b/src/mcp/tools/health.ts
@@ -3,7 +3,7 @@ import type { ManagedRuntime } from "effect";
 import { Effect } from "effect";
 import type { GrafanaError, NotFoundError } from "../../domain/errors.ts";
 import { GrafanaClient } from "../../domain/GrafanaClient.ts";
-import { formatError, formatSuccess } from "../utils.ts";
+import { runTool } from "../utils.ts";
 
 export const registerHealthTools = (
   server: McpServer,
@@ -14,15 +14,13 @@ export const registerHealthTools = (
     "Check the health of the Grafana instance. Returns version, database status, and commit hash.",
     {},
     { title: "Health Check", readOnlyHint: true, openWorldHint: true },
-    async () => {
-      const result = await runtime.runPromiseExit(
+    () =>
+      runTool(
+        runtime,
         Effect.gen(function* () {
           const client = yield* GrafanaClient;
           return yield* client.healthCheck();
         }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
+      ),
   );
 };

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,4 +1,4 @@
-import type { Cause } from "effect";
+import type { Cause, Effect, ManagedRuntime } from "effect";
 import { Cause as CauseModule } from "effect";
 
 export const formatSuccess = (data: unknown) => ({
@@ -19,3 +19,12 @@ export const formatError = (cause: Cause.Cause<unknown>) => ({
   ],
   isError: true as const,
 });
+
+export const runTool = async <R, E, A>(
+  runtime: ManagedRuntime.ManagedRuntime<R, E>,
+  effect: Effect.Effect<A, E, R>,
+) => {
+  const result = await runtime.runPromiseExit(effect);
+  if (result._tag === "Failure") return formatError(result.cause);
+  return formatSuccess(result.value);
+};


### PR DESCRIPTION
## Summary

- Adds a `runTool(runtime, effect)` helper in `src/mcp/utils.ts` that encapsulates the repeated `runPromiseExit` + `_tag === "Failure"` + `formatError`/`formatSuccess` pattern
- Replaces all 15 inline handler bodies across 6 tool files with a single `runTool(...)` call each
- Removes the no-op `Layer.mergeAll(GrafanaClientLive)` wrapper in `main.ts`, passing `GrafanaClientLive` directly to `ManagedRuntime.make`

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] `bun test` — 13/13 pass
- [x] `bun run lint` — no issues

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)