### PR TITLE
fix(domain): make Folder url optional to handle Grafana API responses without url field

### DIFF
--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -45,7 +45,7 @@ export class AlertInstance extends Schema.Class<AlertInstance>("AlertInstance")(
 export class Folder extends Schema.Class<Folder>("Folder")({
   uid: Schema.String,
   title: Schema.String,
-  url: Schema.String,
+  url: Schema.optional(Schema.String),
 }) {}
 
 export class Annotation extends Schema.Class<Annotation>("Annotation")({

--- a/src/infra/GrafanaClientLive.ts
+++ b/src/infra/GrafanaClientLive.ts
@@ -77,7 +77,7 @@ const AlertInstanceSchema = Schema.Struct({
 const FolderSchema = Schema.Struct({
   uid: Schema.String,
   title: Schema.String,
-  url: Schema.String,
+  url: Schema.optional(Schema.String),
 });
 
 const AnnotationSchema = Schema.Struct({


### PR DESCRIPTION
## What

Makes the `url` field optional in both `FolderSchema` (internal decoder in `GrafanaClientLive.ts`) and the `Folder` domain model (`models.ts`).

## Why

Grafana's `/api/folders` endpoint does not always include a `url` field in the response objects. The required `Schema.String` caused:

```
ParseError: Folder (Constructor)
└─ ["url"]
   └─ Expected string, actual undefined
```

This broke `list_folders` on Grafana v12.4.2+.

## Test plan

- [x] `bun test` passes (13 tests)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes

Closes #18