### PR TITLE
feat(tools): add missing idempotentHint and destructiveHint to all 18 tools

### DIFF
--- a/src/mcp/tools/alerts.ts
+++ b/src/mcp/tools/alerts.ts
@@ -14,7 +14,13 @@ export const registerAlertTools = (
     "list_alert_rules",
     "List all Grafana alert rules. Returns uid, title, condition, folder, rule group, and state settings.",
     {},
-    { title: "List Alert Rules", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "List Alert Rules",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     () =>
       runTool(
         runtime,
@@ -31,7 +37,13 @@ export const registerAlertTools = (
     {
       uid: z.string().describe("Alert rule UID"),
     },
-    { title: "Get Alert Rule", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "Get Alert Rule",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ uid }) =>
       runTool(
         runtime,
@@ -46,7 +58,13 @@ export const registerAlertTools = (
     "list_alert_instances",
     "List currently firing Grafana alert instances from Alertmanager. Returns labels, state, and activeAt.",
     {},
-    { title: "List Alert Instances", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "List Alert Instances",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     () =>
       runTool(
         runtime,

--- a/src/mcp/tools/annotations.ts
+++ b/src/mcp/tools/annotations.ts
@@ -17,7 +17,13 @@ export const registerAnnotationTools = (
       dashboardUid: z.string().optional().describe("Filter annotations by dashboard UID"),
       limit: z.number().optional().describe("Maximum number of results (default: 100)"),
     },
-    { title: "List Annotations", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "List Annotations",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ dashboardUid, limit }) =>
       runTool(
         runtime,
@@ -45,6 +51,7 @@ export const registerAnnotationTools = (
       title: "Create Annotation",
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
       openWorldHint: true,
     },
     ({ text, tags, dashboardUid, time, timeEnd }) =>

--- a/src/mcp/tools/dashboards.ts
+++ b/src/mcp/tools/dashboards.ts
@@ -17,7 +17,13 @@ export const registerDashboardTools = (
       query: z.string().optional().describe("Search query to filter dashboards by title"),
       limit: z.number().optional().describe("Maximum number of results (default: 100)"),
     },
-    { title: "List Dashboards", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "List Dashboards",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ query, limit }) =>
       runTool(
         runtime,
@@ -34,7 +40,13 @@ export const registerDashboardTools = (
     {
       uid: z.string().describe("Dashboard UID"),
     },
-    { title: "Get Dashboard", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "Get Dashboard",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ uid }) =>
       runTool(
         runtime,
@@ -55,7 +67,13 @@ export const registerDashboardTools = (
       folderUid: z.string().optional().describe("UID of the folder to place the dashboard in"),
       message: z.string().optional().describe("Commit message for the dashboard version"),
     },
-    { title: "Create Dashboard", readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    {
+      title: "Create Dashboard",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     ({ dashboardJson, folderUid, message }) =>
       runTool(
         runtime,
@@ -74,7 +92,13 @@ export const registerDashboardTools = (
       dashboardJson: z.string().describe("Updated dashboard JSON as a string"),
       message: z.string().optional().describe("Commit message for the new version"),
     },
-    { title: "Update Dashboard", readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    {
+      title: "Update Dashboard",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     ({ uid, dashboardJson, message }) =>
       runTool(
         runtime,
@@ -91,7 +115,13 @@ export const registerDashboardTools = (
     {
       uid: z.string().describe("Dashboard UID"),
     },
-    { title: "Delete Dashboard", readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+    {
+      title: "Delete Dashboard",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ uid }) =>
       runTool(
         runtime,

--- a/src/mcp/tools/datasources.ts
+++ b/src/mcp/tools/datasources.ts
@@ -14,7 +14,13 @@ export const registerDatasourceTools = (
     "list_datasources",
     "List all configured Grafana datasources. Returns id, uid, name, type, url, and isDefault.",
     {},
-    { title: "List Datasources", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "List Datasources",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     () =>
       runTool(
         runtime,
@@ -31,7 +37,13 @@ export const registerDatasourceTools = (
     {
       uid: z.string().describe("Datasource UID"),
     },
-    { title: "Get Datasource", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "Get Datasource",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ uid }) =>
       runTool(
         runtime,
@@ -55,6 +67,7 @@ export const registerDatasourceTools = (
       title: "Create Datasource",
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
       openWorldHint: true,
     },
     ({ name, type, url, isDefault }) =>
@@ -73,7 +86,13 @@ export const registerDatasourceTools = (
     {
       uid: z.string().describe("Datasource UID"),
     },
-    { title: "Delete Datasource", readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+    {
+      title: "Delete Datasource",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ uid }) =>
       runTool(
         runtime,

--- a/src/mcp/tools/folders.ts
+++ b/src/mcp/tools/folders.ts
@@ -14,7 +14,13 @@ export const registerFolderTools = (
     "list_folders",
     "List all Grafana folders. Returns uid, title, and url.",
     {},
-    { title: "List Folders", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "List Folders",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     () =>
       runTool(
         runtime,
@@ -32,7 +38,13 @@ export const registerFolderTools = (
       title: z.string().describe("Folder title"),
       uid: z.string().optional().describe("Optional custom UID for the folder"),
     },
-    { title: "Create Folder", readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    {
+      title: "Create Folder",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     ({ title, uid }) =>
       runTool(
         runtime,
@@ -49,7 +61,13 @@ export const registerFolderTools = (
     {
       uid: z.string().describe("Folder UID"),
     },
-    { title: "Delete Folder", readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+    {
+      title: "Delete Folder",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     ({ uid }) =>
       runTool(
         runtime,

--- a/src/mcp/tools/health.ts
+++ b/src/mcp/tools/health.ts
@@ -13,7 +13,13 @@ export const registerHealthTools = (
     "health_check",
     "Check the health of the Grafana instance. Returns version, database status, and commit hash.",
     {},
-    { title: "Health Check", readOnlyHint: true, openWorldHint: true },
+    {
+      title: "Health Check",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     () =>
       runTool(
         runtime,


### PR DESCRIPTION
## What

All 18 `server.tool()` calls across the 6 tool files now include the complete set of four annotations:
- `readOnlyHint` — was already present on most
- `destructiveHint` — was missing on all read-only tools
- `idempotentHint` — was missing on all 18 tools
- `openWorldHint` — was already present on all

## Why

The MCP blueprint requires all four hints on every tool registration. Missing hints reduce the quality of information available to MCP clients about tool behaviour.

## Test plan

- [x] `bun test` passes (13 tests)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes

Closes #19