### PR TITLE
chore: remove spurious tests/**/* from tsconfig include

### DIFF
--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -11,5 +11,5 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": true,
     "types": ["bun-types"]
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## What

Removes the dead \`"tests/**/*"\` entry from \`include\` in both \`tsconfig.json\` and \`tsconfig.check.json\`.

## Why

There is no \`tests/\` directory in this repo — all test files live under \`src/\`. The spurious entry is confusing and inconsistent with the canonical tsconfig from utils.md.

## Test plan

- [x] \`bun run lint\` passes
- [x] \`bun run typecheck\` passes

Closes #20