### PR TITLE
fix(annotations): handle string-encoded JSON arrays for tags param

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "files": {
-    "includes": ["**", "!dist", "!node_modules"]
+    "includes": ["**", "!dist", "!node_modules", "!.claude"]
   },
   "formatter": {
     "enabled": true,

--- a/src/mcp/tools/annotations.ts
+++ b/src/mcp/tools/annotations.ts
@@ -39,7 +39,9 @@ export const registerAnnotationTools = (
     "Create a Grafana annotation, optionally pinned to a dashboard.",
     {
       text: z.string().describe("Annotation text / description"),
-      tags: z.array(z.string()).describe("Tags to attach to the annotation"),
+      tags: z
+        .union([z.array(z.string()), z.string().transform((s) => JSON.parse(s) as string[])])
+        .describe("Tags to attach to the annotation"),
       dashboardUid: z.string().optional().describe("Dashboard UID to attach the annotation to"),
       time: z.number().optional().describe("Epoch time in milliseconds (default: now)"),
       timeEnd: z


### PR DESCRIPTION
## Summary

- Some MCP clients (e.g. Claude Desktop) serialise array tool arguments as JSON strings before passing them over the MCP protocol. The `tags` parameter in `create_annotation` was declared as `z.array(z.string())`, which rejects a string value and throws `Expected array, received string`.
- Changed the schema to `z.union([z.array(z.string()), z.string().transform(s => JSON.parse(s) as string[])])` so both a native `string[]` and a stringified JSON array are accepted.
- Also excluded `.claude/` from biome.json to prevent formatter errors on local settings files.

## Test plan

- [ ] Run `npm run build` — should succeed with no errors
- [ ] Run `npm run lint` — should pass cleanly
- [ ] Run `npm test` — all 13 tests pass
- [ ] Call `create_annotation` via an MCP client that serialises arrays as strings and verify the annotation is created without error

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)